### PR TITLE
fix(ssh): keep the service port, and expand ~ in IdentityFile

### DIFF
--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sio2boss/ssh_config"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 )
 
 func loadPrivateKey(t *Tunnel, keyPath string) (ssh.AuthMethod, error) {
@@ -81,6 +82,39 @@ func (k *knownHosts) Callback(t *Tunnel) ssh.HostKeyCallback {
 	}
 }
 
+// expandHome resolves a leading "~" the way ssh(1) does.
+func expandHome(path, home string) string {
+	if path == "~" {
+		return home
+	}
+	if strings.HasPrefix(path, "~/") {
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}
+
+// agentAuthMethod returns an auth method backed by the running ssh-agent, or
+// nil when there is no agent to talk to.
+func agentAuthMethod(t *Tunnel) ssh.AuthMethod {
+	sock := os.Getenv("SSH_AUTH_SOCK")
+	if sock == "" {
+		return nil
+	}
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.logf("ssh-agent at %s not reachable: %v", sock, err)
+		return nil
+	}
+	ag := agent.NewClient(conn)
+	keys, err := ag.List()
+	if err != nil {
+		t.logf("ssh-agent gave no keys: %v", err)
+		return nil
+	}
+	t.logf("Using ssh-agent with %d key(s)", len(keys))
+	return ssh.PublicKeysCallback(ag.Signers)
+}
+
 func GetSSHConfig(t *Tunnel) (*ssh.ClientConfig, error) {
 	// Find home directory
 	home, err := os.UserHomeDir()
@@ -110,10 +144,14 @@ func GetSSHConfig(t *Tunnel) (*ssh.ClientConfig, error) {
 
 	// We will resolve this host in the SSH config file
 	lookupHost := &t.Config.Bastion.Host
+	// The Port from the SSH config is the port we SSH to, never the port of the
+	// service being forwarded. With no bastion, figureOutRemoteVsBastion reads
+	// the SSH port from Bastion.Port (defaulting to 22) and forwards to
+	// localhost:RemotePort, so this must land on Bastion.Port either way --
+	// pointing it at RemotePort would send every tunnel to the remote's sshd.
 	lookupPort := &t.Config.Bastion.Port
 	if t.Config.Bastion.Host == "" {
 		lookupHost = &t.Config.RemoteHost
-		lookupPort = &t.Config.RemotePort
 	}
 
 	// Load SSH config file
@@ -141,10 +179,15 @@ func GetSSHConfig(t *Tunnel) (*ssh.ClientConfig, error) {
 				sshUser = user
 			}
 
-			// Add identity file to auths
+			// Add identity file to auths. The SSH config keeps these paths as
+			// written, so "~/.ssh/id_ed25519" arrives literally and os.ReadFile
+			// would never find it.
 			if identityFiles, _ := sshConfig.GetAll(*lookupHost, "IdentityFile"); len(identityFiles) > 0 {
 				t.logf("Overriding identity with %d files from SSH config", len(identityFiles))
-				keyPaths = identityFiles
+				keyPaths = nil
+				for _, p := range identityFiles {
+					keyPaths = append(keyPaths, expandHome(p, home))
+				}
 			}
 
 			// override lookupHost with HostName from SSH config
@@ -162,6 +205,12 @@ func GetSSHConfig(t *Tunnel) (*ssh.ClientConfig, error) {
 			t.logf("Loaded identity file: %s", keyPath)
 			auths = append(auths, auth)
 		}
+	}
+
+	// An encrypted or absent key file is normal when the user works through an
+	// agent; without this the handshake offers no method at all and fails.
+	if agentAuth := agentAuthMethod(t); agentAuth != nil {
+		auths = append(auths, agentAuth)
 	}
 
 	config := &ssh.ClientConfig{

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -1,0 +1,118 @@
+package ssh
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"tunnel9/internal/config"
+)
+
+// writeSSHHome builds a throwaway $HOME containing .ssh/config, and returns it.
+func writeSSHHome(t *testing.T, sshConfig string) string {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".ssh"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".ssh", "config"), []byte(sshConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	return home
+}
+
+func newTestTunnel(t *testing.T, tc config.TunnelConfig) *Tunnel {
+	t.Helper()
+	tun := &Tunnel{ID: "test", Config: tc, LogChan: make(chan string, 100)}
+	// Drain the log channel so logf never blocks on the buffer.
+	go func() {
+		for range tun.LogChan {
+		}
+	}()
+	t.Cleanup(func() { close(tun.LogChan) })
+	return tun
+}
+
+// The Port in the SSH config is the port we SSH to. Writing it into
+// RemotePort would point every forward at the remote's sshd instead of at the
+// service the user asked for.
+func TestGetSSHConfigKeepsRemotePort(t *testing.T) {
+	writeSSHHome(t, "Host dev\n    HostName dev.example.com\n    Port 2222\n")
+
+	tun := newTestTunnel(t, config.TunnelConfig{
+		Name:       "postgres",
+		RemoteHost: "dev",
+		LocalPort:  15432,
+		RemotePort: 5432,
+	})
+	if _, err := GetSSHConfig(tun); err != nil {
+		t.Fatalf("GetSSHConfig: %v", err)
+	}
+
+	if tun.Config.RemotePort != 5432 {
+		t.Errorf("RemotePort = %d, want 5432 (the service port must survive)", tun.Config.RemotePort)
+	}
+	if tun.Config.Bastion.Port != 2222 {
+		t.Errorf("Bastion.Port = %d, want 2222 (the SSH port belongs here)", tun.Config.Bastion.Port)
+	}
+
+	sshEndpoint, remoteEndpoint := figureOutRemoteVsBastion(tun.Config)
+	if got, want := sshEndpoint.String(), "dev.example.com:2222"; got != want {
+		t.Errorf("ssh endpoint = %s, want %s", got, want)
+	}
+	if got, want := remoteEndpoint.String(), "localhost:5432"; got != want {
+		t.Errorf("remote endpoint = %s, want %s", got, want)
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	tests := []struct {
+		name, path, want string
+	}{
+		{"tilde slash", "~/.ssh/id_ed25519", "/home/u/.ssh/id_ed25519"},
+		{"bare tilde", "~", "/home/u"},
+		{"absolute path untouched", "/etc/ssh/key", "/etc/ssh/key"},
+		{"relative path untouched", "keys/id", "keys/id"},
+		{"tilde user not expanded", "~other/.ssh/id", "~other/.ssh/id"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := expandHome(tt.path, "/home/u"); got != tt.want {
+				t.Errorf("expandHome(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+// An IdentityFile is stored as written, so "~/.ssh/id_ed25519" reaches us
+// literally and os.ReadFile would never find it.
+func TestIdentityFileTildeIsExpanded(t *testing.T) {
+	home := writeSSHHome(t, "Host dev\n    HostName dev.example.com\n    IdentityFile ~/.ssh/id_test\n")
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(home, ".ssh", "id_test")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(block), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tun := newTestTunnel(t, config.TunnelConfig{Name: "svc", RemoteHost: "dev", RemotePort: 5432})
+	clientConfig, err := GetSSHConfig(tun)
+	if err != nil {
+		t.Fatalf("GetSSHConfig: %v", err)
+	}
+	if len(clientConfig.Auth) == 0 {
+		t.Fatal("no auth methods: the tilde in IdentityFile was not expanded")
+	}
+}


### PR DESCRIPTION
Two bugs in `GetSSHConfig` combined to keep every tunnel from working on my setup. Each is small; together they made the tunnel silently connect to nothing.

### 1. The SSH port overwrites the service port

```go
lookupPort := &t.Config.Bastion.Port
if t.Config.Bastion.Host == "" {
    lookupHost = &t.Config.RemoteHost
    lookupPort = &t.Config.RemotePort   // <-- here
}
...
*lookupPort = portNum   // Port from the SSH config
```

With no bastion, the `Port` from `~/.ssh/config` lands in `Config.RemotePort` — the port of the service being forwarded. Most SSH configs carry an explicit `Port 22`, so a tunnel defined as `local 15432 -> remote 5432` is rewritten to `remote 22` before the first connection, and `figureOutRemoteVsBastion` then forwards to `localhost:22`. Every tunnel reaches the remote's sshd instead of the service.

A non-default SSH port is wrong twice over: it never reaches the SSH connection (which stays on 22, since that path reads `Bastion.Port`) and it clobbers the service port. Writing it to `Bastion.Port` fixes both at once, since that is exactly where `figureOutRemoteVsBastion` looks for the SSH port when no bastion is set.

### 2. `IdentityFile` is not tilde-expanded

`ssh_config` returns the path as written, and `ssh-keygen` writes `~/.ssh/id_ed25519` into configs by default. `os.ReadFile("~/.ssh/id_ed25519")` never resolves, so no key loads and the handshake offers nothing:

```
DEBUG [svc] Failed to find key at ~/.ssh/id_ed25519
ERROR [svc] SSH connection failed: ssh: handshake failed: ssh: unable to
      authenticate, attempted methods [none], no supported methods remain
```

This expands a leading `~` the way ssh(1) does. It also offers the running ssh-agent as a fallback when `SSH_AUTH_SOCK` is set, which covers an encrypted key file too — `attempted methods [none]` should not be reachable when the user has a working agent.

### Tests

`internal/ssh/config_test.go` covers both against a throwaway `$HOME`, no network. Both fail before the change:

```
config_test.go:58: RemotePort = 2222, want 5432 (the service port must survive)
config_test.go:61: Bastion.Port = 0, want 2222 (the SSH port belongs here)
config_test.go:66: ssh endpoint = dev.example.com:22, want dev.example.com:2222
config_test.go:69: remote endpoint = localhost:2222, want localhost:5432
config_test.go:97: no auth methods: the tilde in IdentityFile was not expanded
```

`go test ./...` and `go vet ./...` are clean after it. Verified end to end against a real remote: six tunnels (Postgres, Redis, two Mailpit ports, two HTTP dev servers) all serve their real protocol through the TUI.

Happy to split this into two commits or drop the ssh-agent fallback if you would rather keep that separate.